### PR TITLE
fix: Explicitly set PYTHONPATH for backend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     build: ./gcv/backend
     container_name: gcv_backend
     working_dir: /app
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: sh -c "PYTHONPATH=. uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
     volumes:
       - ./gcv/backend/app:/app
     ports:


### PR DESCRIPTION
- Modifies the `command` in `docker-compose.yml` for the backend service to `sh -c "PYTHONPATH=. uvicorn app.main:app ..."`.
- This explicitly sets the `PYTHONPATH` to the current working directory (`/app`) before running uvicorn.
- This is a more robust fix to ensure the `app` module is found, resolving the persistent `ModuleNotFoundError`.