### PR TITLE
fix: Downgrade Python base image to 3.10 for stability

### DIFF
--- a/gcv/backend/Dockerfile
+++ b/gcv/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.10-slim-buster
 
 # WORKDIR define o diretório de execução E o adiciona ao PYTHONPATH
 WORKDIR /app


### PR DESCRIPTION
- Changes the backend Dockerfile's base image from `python:3.12-slim` to `python:3.10-slim-buster`.
- This is intended to resolve a persistent, silent startup failure (`net::ERR_EMPTY_RESPONSE` on the frontend) likely caused by a subtle package incompatibility with Python 3.12.
- Python 3.10 offers a more stable and widely compatible environment for the current set of dependencies.